### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/EnotPoloskun/ember-unchanged-attributes.git",
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
This means that the NPM registry will pick up this value and downstream thing like [Ember Observer](https://emberobserver.com/) will be able to display/use it.